### PR TITLE
Use https:// url instead of ssh one for a public dataset

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "input"]
 	path = input
-	url = git@github.com:datalad-handbook/iris_data.git
+	url = https://github.com/datalad-handbook/iris_data
 	datalad-id = 5800e71c-09f9-11ea-98f1-e86a64c8054c


### PR DESCRIPTION
So that users could "datalad rerun" the handbook tutorial without needing ssh setup.

ref: https://github.com/datalad/tutorials/issues/24